### PR TITLE
Enable linter tooltips to overflow

### DIFF
--- a/styles/linter-ui.less
+++ b/styles/linter-ui.less
@@ -50,3 +50,9 @@ linter-bottom-status {
     color: @background-color-error;
   }
 }
+
+// Make linter tooltips overflow
+atom-text-editor::shadow  .gutter[gutter-name="linter-ui-default"] {
+  z-index: 1;
+  overflow: visible;
+}


### PR DESCRIPTION
Not sure if this is future proof, since it uses the `gutter-name="linter-ui-default"` attribute selector. Will there be something like `linter-ui-custom` or so? Then it won't work. Well, I guess the custom UI styles would need to do the same.