### PR TITLE
Remove bubbles even when the cursor keeps moving

### DIFF
--- a/lib/editor.js
+++ b/lib/editor.js
@@ -51,6 +51,11 @@ export default class Editor {
     }))
     this.subscriptions.add(disposableEvent(editorElement, 'mousemove', debounce(e => {
       if (editorElement.component && e.target.nodeName === 'ATOM-TEXT-EDITOR') {
+        this.removeBubble()
+      }
+    }, 200, true)))
+    this.subscriptions.add(disposableEvent(editorElement, 'mousemove', debounce(e => {
+      if (editorElement.component && e.target.nodeName === 'ATOM-TEXT-EDITOR') {
         this.cursorPosition = textEditor.bufferPositionForScreenPosition(editorElement.component.screenPositionForMouseEvent(e))
         this.updateBubble()
       } // The property is removed after an editor is disposed
@@ -63,13 +68,15 @@ export default class Editor {
       }
     }, 60)))
   }
-  updateBubble(position: ?Point = null) {
-    position = position || this.cursorPosition || this.textEditor.getCursorBufferPosition()
-
+  removeBubble() {
     if (this.bubble) {
       this.bubble.destroy()
       this.bubble = null
     }
+  }
+  updateBubble(position: ?Point = null) {
+    position = position || this.cursorPosition || this.textEditor.getCursorBufferPosition()
+    this.removeBubble()
 
     const messages = getMessagesOnPoint(this.buffer.messages, this.textEditor.getPath(), position)
 
@@ -95,8 +102,6 @@ export default class Editor {
     if (this.gutter) {
       this.gutter.destroy()
     }
-    if (this.bubble) {
-      this.bubble.destroy()
-    }
+    this.removeBubble()
   }
 }


### PR DESCRIPTION
Currently the bubble is not removed if the cursor keeps moving. It is removed 200ms **after the cursor stops moving**. This PR makes sure the bubble is removed as soon as possible, adding the bubble remains the same way